### PR TITLE
Test: full-circle submission (please close)

### DIFF
--- a/content/use-cases/full-circle-test.md
+++ b/content/use-cases/full-circle-test.md
@@ -1,0 +1,39 @@
+---
+type: use-case
+slug: full-circle-test
+headline: "Fork, file, validate, PR: proving the outside-contributor path"
+summary: "This entry is a submission-pipeline test opened by a first-time external contributor account with no repo access, to check that fork, local validate, and pull request all work exactly as CONTRIBUTING.md describes for a real submitter."
+categories: [engineering]
+format: use-case
+author:
+  handle: full_circle_test
+  url: https://github.com/full_circle_test
+  platform: github
+prompt_provenance: curator
+replicability: "Not a real build to replicate — it exists only to exercise the fork-and-PR flow a genuine submitter would use, following CONTRIBUTING.md end to end."
+added_at: "2026-08-22T00:00:00Z"
+updated_at: "2026-08-22T00:00:00Z"
+status: proposed
+---
+
+## How it's set up
+
+1. This is a clearly-labelled **submission-pipeline test**, not a real agent use case — it exists to prove that an outside, non-collaborator GitHub account can complete the community contribution flow end to end.
+2. The submitting account forked `ZeroPointRepo/GrokBotDev` to its own namespace with no prior write access to the upstream repository.
+3. It cloned the fork, created a branch, and added exactly one new Markdown file under `content/use-cases/`, matching the filename to the `slug` field as CONTRIBUTING.md §1 requires.
+4. It ran `npm ci && node scripts/validate.mjs` locally on the fork and confirmed the file passes schema, slug, and vocabulary checks before opening anything.
+5. It pushed the branch to the fork and opened a pull request against `main`, expecting the repo's first-time-contributor checks (CI gating, required approval) to apply exactly as they would to any other newcomer.
+
+## Prompt
+
+```text
+You are not a real agent for this entry. This block exists only so the submission
+passes the schema's "exactly one fenced prompt block, at least 200 characters" rule
+for a use-case entry. There is no product, workflow, or claim behind it — it stands
+in for the prompt field while the fork-to-pull-request pipeline is being exercised
+by an external test account that holds no write access to the target repository.
+```
+
+## Why it's cool
+
+It isn't cool — it's a plumbing check. The interesting part is what it proves: that a person who has never touched this repository before can read CONTRIBUTING.md, fork it, write one valid file by hand, run the same validator the CI runs, and land a pull request without asking a maintainer for anything first. That is the whole promise of a file-based, PR-driven content model, and this entry is the receipt that the promise holds for a true outsider account.


### PR DESCRIPTION
## What this is

This is a **dry-run test** of the community contribution pipeline, opened from an external
account (`stayingapi`) that has no collaborator/write access to this repository — to verify
the outside-contributor path described in `CONTRIBUTING.md` works end to end:

1. Forked the repo (no prior access).
2. Added exactly one new file, `content/use-cases/full-circle-test.md`, following
   CONTRIBUTING.md §3.4 (`status: proposed`, no `verified_at`, real-shaped fields, an
   `author` credit using the fictional handle `full_circle_test`, and the three required
   body sections meeting their length rules).
3. Ran `npm ci && node scripts/validate.mjs` on the fork — result: `validate: OK`.
4. Pushed the branch and opened this PR to `main`.

The entry is clearly labelled in its own body as a submission-pipeline test, not a real
agent use case, and does not attribute any claim to a real person's work.

**Please do not merge** — this PR exists only to observe CI/labels/mergeable state on a
genuine first-time external contribution. A maintainer can close/clean this up once
verified.