### PR TITLE
feat: add TubeAlfred plugin

### DIFF
--- a/content/plugins/tubealfred.md
+++ b/content/plugins/tubealfred.md
@@ -4,12 +4,12 @@ name: "TubeAlfred"
 slug: tubealfred
 tagline: "Give your Grok Bot read-only access to any public YouTube video, channel, or playlist."
 category: data
-subcategory: youtube
+subcategory: enrichment
 install_steps:
-  - "Connect the TubeAlfred MCP server at https://mcp.tubealfred.com — no account or API key needed."
-  - "Tell your Grok Bot to use TubeAlfred whenever you share a YouTube link or ask about a video, channel, or playlist."
+  - "Create a TubeAlfred API key at https://tubealfred.com/app/api-keys."
+  - "Connect the TubeAlfred MCP server and give your Grok Bot the key."
   - "Paste the prompt below so this becomes a standing capability."
-prompt: "You have access to TubeAlfred, an MCP server for public YouTube data — no API key needed. Whenever I share a YouTube URL or ask about a video, channel, playlist, or search term, use TubeAlfred's tools: youtube_url_resolve to identify what a link points to, then the matching tool for video/channel/playlist details, comments, transcripts, or search. Never invent metadata, view counts, or transcript text that a tool call didn't actually return — if a tool errors or a resource is private, tell me instead of guessing. Confirm the connection first by resolving one YouTube URL I give you."
+prompt: "Read TubeAlfred's docs at https://tubealfred.com/docs, then integrate via its MCP server using my TubeAlfred API key. Whenever I share a YouTube URL or ask about a video, channel, playlist, or search term, resolve it first, then call the matching tool for details, transcript, comments, or search. Never invent an endpoint, field, metadata, view count, or transcript text that a tool call didn't actually return — if a tool errors or a resource is private, tell me instead of guessing. Confirm the connection first by resolving one YouTube URL I give you."
 works_with: []
 project_url: "https://tubealfred.com"
 x_handle: "TubeAlfred"
@@ -28,8 +28,8 @@ status: proposed
 
 ## What it does
 
-TubeAlfred gives AI agents read-only access to public YouTube data — videos, channels, playlists, comments, transcripts, search, and trending — through a hosted MCP server, no API key required.
+TubeAlfred is a YouTube API and hosted MCP server covering video, channel, transcript, comment, reply, playlist, community, search, hashtag, and trending endpoints — 35 REST endpoints and 34 MCP tools total.
 
 ## Use it in Grok Bot
 
-Connect the MCP server and paste the prompt. From then on your bot can resolve any YouTube URL, pull video/channel/playlist metadata, fetch transcripts, read comments, and search or browse trending content directly in chat.
+Connect the MCP server with an API key and paste the prompt. Your bot reads TubeAlfred's docs first, confirms the connection, then from then on can resolve any YouTube URL, pull video/channel/playlist metadata, fetch transcripts, read comments, and search or browse trending content directly in chat.

--- a/content/plugins/tubealfred.md
+++ b/content/plugins/tubealfred.md
@@ -1,0 +1,35 @@
+---
+type: plugin
+name: "TubeAlfred"
+slug: tubealfred
+tagline: "Give your Grok Bot read-only access to any public YouTube video, channel, or playlist."
+category: data
+subcategory: youtube
+install_steps:
+  - "Connect the TubeAlfred MCP server at https://mcp.tubealfred.com — no account or API key needed."
+  - "Tell your Grok Bot to use TubeAlfred whenever you share a YouTube link or ask about a video, channel, or playlist."
+  - "Paste the prompt below so this becomes a standing capability."
+prompt: "You have access to TubeAlfred, an MCP server for public YouTube data — no API key needed. Whenever I share a YouTube URL or ask about a video, channel, playlist, or search term, use TubeAlfred's tools: youtube_url_resolve to identify what a link points to, then the matching tool for video/channel/playlist details, comments, transcripts, or search. Never invent metadata, view counts, or transcript text that a tool call didn't actually return — if a tool errors or a resource is private, tell me instead of guessing. Confirm the connection first by resolving one YouTube URL I give you."
+works_with: []
+project_url: "https://tubealfred.com"
+x_handle: "TubeAlfred"
+founder:
+  x_handle: "rakesh_rry"
+author:
+  handle: "tubealfred"
+  url: "https://tubealfred.com"
+  platform: web
+pricing_note: "Free tier; paid plans available."
+setup_minutes: 5
+added_at: "2026-08-24T00:00:00Z"
+updated_at: "2026-08-24T00:00:00Z"
+status: proposed
+---
+
+## What it does
+
+TubeAlfred gives AI agents read-only access to public YouTube data — videos, channels, playlists, comments, transcripts, search, and trending — through a hosted MCP server, no API key required.
+
+## Use it in Grok Bot
+
+Connect the MCP server and paste the prompt. From then on your bot can resolve any YouTube URL, pull video/channel/playlist metadata, fetch transcripts, read comments, and search or browse trending content directly in chat.


### PR DESCRIPTION
> 📕 **Read [CONTRIBUTING.md](https://github.com/ZeroPointRepo/GrokBotDev/blob/main/CONTRIBUTING.md) first** — it's the rulebook (every field, the quality bar, the Awesome Score). Reviewers cite it by rule number (G1–G8, UC-n, PL-n).

## What this adds
Adds TubeAlfred (plugin), an MCP server giving Grok Bots read-only access to public YouTube data — videos, channels, playlists, comments, transcripts, search, and trending.

- category: data / enrichment
- follows the plugin frontmatter spec in CONTRIBUTING.md
- status: proposed

## Checklist
- [x] This PR adds exactly ONE new file under `content/` (plus assets for this entry, if any).
- [x] It follows [CONTRIBUTING.md](https://github.com/ZeroPointRepo/GrokBotDev/blob/main/CONTRIBUTING.md) — required fields + the golden rules (G1–G8).
- [x] `npm run validate` passes locally (schema, slug, vocabularies).
- [x] `slug` is kebab-case and exactly matches the filename.
- [x] I ran / used this myself end to end — it works today.
- [x] Every URL in the frontmatter resolves to real, relevant content.
- [x] The prompt body is the real, complete prompt — not a summary or a teaser.
- [x] The entry body is plain markdown — no raw HTML (`<script>`, `<iframe>`, `<style>`, `<form>`, inline event handlers). CI rejects it (§8.5).
- [x] I did NOT set `verified_at` or `status: live` — a maintainer sets those during verification (§10.1).
- [x] This is not an ad. A listing that exists to funnel traffic to your product gets closed. Sponsor slots will exist for that — this isn't one.
- [x] `author` is me, TubeAlfred's founder/maker — this is my own work, not someone else's, so `scouted_by` doesn't apply.
- N/A — no YouTube video primary source (this is a plugin submission, not a use case).
- [x] I license this contribution under CC BY 4.0 (attribution: entry author + grokbot.dev).

## Where it came from
My own product — [tubealfred.com](https://tubealfred.com), docs at [tubealfred.com/docs](https://tubealfred.com/docs).