### PR TITLE
Add Pallyy plugin

### DIFF
--- a/content/plugins/pallyy.md
+++ b/content/plugins/pallyy.md
@@ -1,0 +1,37 @@
+---
+type: plugin
+name: "Pallyy"
+slug: pallyy
+tagline: "Let your agent draft, schedule, and publish social posts through Pallyy's REST API."
+category: marketing
+subcategory: social
+install_steps:
+  - "Create a Pallyy account at pallyy.com and connect the social profiles you want your agent to post to."
+  - "On any paid plan (every plan has a 14-day trial), generate an API key at app.pallyy.com/settings/api-keys with the scopes you need: Edit posts, Publish posts, and Upload media."
+  - "Paste the prompt below into your Grok Bot and give it your Pallyy API key so this becomes a standing capability."
+prompt: "You are setting up a Pallyy integration for me inside Grok Bot. First, read Pallyy's API documentation at https://pallyy.com/docs/api so you understand how it works: bearer auth with an API key from Settings > API keys, base URL https://app.pallyy.com/api/v1, and endpoints for listing social sets (groups of connected profiles), creating and updating post sets (drafts and scheduled posts with per-network captions), listing media, and uploading media by URL. Then, whenever I ask you to draft or schedule posts across my connected profiles, use the Pallyy API to do it: pick the right social set, write the captions I ask for, and schedule at the time I give you. Rules: follow the documentation exactly and never invent an endpoint, field, or parameter Pallyy does not document; respect the 5 requests per second rate limit and back off when you get a 429; and if I ask for something the API cannot do (like analytics), tell me instead of guessing. Always show me the exact post text, profiles, and time before anything is scheduled or published, and confirm the connection first by listing my social sets."
+works_with: ["X"]
+project_url: "https://pallyy.com"
+source_url: "https://pallyy.com/docs/api"
+x_handle: "pallyysocial"
+founder:
+  name: "Tim"
+  x_handle: "Timb03"
+author:
+  handle: "pallyysocial"
+  url: "https://pallyy.com"
+  platform: web
+pricing_note: "Free plan available; the API is included on every paid plan, each with a 14-day trial."
+setup_minutes: 5
+added_at: "2026-08-27T00:00:00Z"
+updated_at: "2026-08-27T00:00:00Z"
+status: proposed
+---
+
+## What it does
+
+Pallyy is a social media scheduling platform with a public REST API built for exactly this kind of agent work. An agent with a scoped API key can list your connected social profiles (organized into social sets), create and update post sets as drafts or scheduled posts with per-network captions, upload media by URL, and read back publishing results including the live permalink for each published post. Keys are read-only until you grant write scopes, can be restricted to a single social set, and every post an agent creates shows the key's name in the post history, so you can always see what your bot did.
+
+## Use it in Grok Bot
+
+Generate an API key in Pallyy under Settings > API keys, grant it only the scopes your bot needs (drafting works with Edit posts alone; add Publish posts when you trust it to schedule), and paste the prompt on this page into your Grok Bot with the key. The bot reads Pallyy's API docs first, then drives your scheduling in plain language, and it confirms the exact post, profiles, and time with you before anything goes out.


### PR DESCRIPTION
## What this adds

Pallyy (plugin) — a social media scheduling platform with a public REST API an agent can use to list connected profiles, draft and schedule posts with per-network captions, and upload media.

## Checklist
- [x] This PR adds exactly ONE new file under `content/` (plus assets for this entry, if any).
- [x] It follows [CONTRIBUTING.md](https://github.com/ZeroPointRepo/GrokBotDev/blob/main/CONTRIBUTING.md) — required fields + the golden rules (G1–G8).
- [x] `npm run validate` passes locally (schema, slug, vocabularies).
- [x] `slug` is kebab-case and exactly matches the filename.
- [x] I ran / used this myself end to end — it works today.
- [x] Every URL in the frontmatter resolves to real, relevant content.
- [x] The prompt body is the real, complete prompt — not a summary or a teaser.
- [x] The entry body is plain markdown — no raw HTML (`<script>`, `<iframe>`, `<style>`, `<form>`, inline event handlers). CI rejects it (§8.5).
- [x] I did NOT set `verified_at` or `status: live` — a maintainer sets those during verification (§10.1).
- [x] This is not an ad. A listing that exists to funnel traffic to your product gets closed. Sponsor slots will exist for that — this isn't one.
- [x] If this is someone else's work: `author` is the original creator, the origin is linked (`source_url` for a plugin, `source_tweets[]` for a use case), and `scouted_by` is me.
- [x] If the source is a YouTube video: `primary_source` is `kind: youtube-video` with a `youtube.com/watch`, `youtu.be/` or `youtube.com/shorts/` URL, plus the video's real `title` and `channel` — those two are required because they are what the page shows if the player never loads. `timestamp` is optional and is written `mm:ss`.
- [x] I license this contribution under CC BY 4.0 (attribution: entry author + grokbot.dev).

## Where it came from

I'm the founder of Pallyy. The API this entry describes shipped publicly in August 2026: docs at https://pallyy.com/docs/api, feature overview at https://pallyy.com/features/api.