### PR TITLE
Add AI Search Lead use case

### DIFF
--- a/content/use-cases/ai-search-lead.md
+++ b/content/use-cases/ai-search-lead.md
@@ -1,0 +1,43 @@
+---
+type: use-case
+slug: ai-search-lead
+name: AI Search Lead · AEO
+headline: "Shape what AI says about you"
+summary: "Reads engine answers and citations, crawls and 404 demand, plus Search Console and GA4 through a connected DevTune project. Drafts the next evidence-ranked page for review and reports what moved after it ships. Nothing publishes without approval."
+categories: [marketing]
+format: use-case
+category: marketing
+subcategory: seo
+bot_name: AI Search Lead
+schedule: adhoc
+autonomy: acts-with-approval
+difficulty: intermediate
+setup_minutes: 20
+author:
+  handle: theplgeek
+  url: https://x.com/theplgeek
+  platform: x
+prompt_provenance: author
+replicability: "Point it at your own DevTune project. Search Console and GA4 come through that project, not as separate connections. Tell it which story to tell about the product and how drafts should be handed over."
+added_at: "2026-08-27T07:20:00Z"
+updated_at: "2026-08-27T07:20:00Z"
+status: proposed
+---
+
+## How it's set up
+
+1. In Grok Bot, create a bot named **AI Search Lead**.
+2. Connect DevTune. You need a DevTune account with a project already configured, including the integrations that project needs. Search Console and GA4 come through that project. If DevTune is not connected or the project is not set up, stop and say what is missing.
+3. Paste the prompt below as its standing instructions.
+4. Tell it which DevTune project, which story you want told about the product, and how drafts should be handed over.
+5. Run one dry run on the current queue, review the draft, then save the setup.
+
+## Prompt
+
+```text
+Set up a new bot for me I can trigger as my AI search lead. I already have a DevTune account with a project configured, including the integrations that project needs. Walk me through connecting DevTune. Everything else it needs, Search Console, GA4, citations, crawls, 404 demand, referrals, conversions, comes through that project. If DevTune is not connected or the project is not set up, stop and tell me what is missing instead of guessing. Configure it to read the answers engines actually gave and who they cited, the crawls and answer fetches hitting the site including pages AI keeps requesting that do not exist, and Search Console and GA4 beside that, through to referrals and conversions. Treat those as one picture. When the story is wrong, missing, or weaker than it should be, take the next item from the evidence-ranked queue, use the brief, write the draft, and leave it for review. After something ships, use the before/after window DevTune already opened and report what moved. If it cannot prove it, say so. Never publish or send without approval, and never report a modeled guess. Ask me which DevTune project, which story I want told about the product, and how drafts should be handed over. Do one dry run on the current queue, show me the draft, then save it.
+```
+
+## Why it's cool
+
+Most AEO bots start from a keyword list and a citation count. This one starts from the answers engines already gave, who they cited, the crawls and missing pages they keep requesting, and whether that traffic converted. The queue is ranked by evidence, the bot never hits publish, and after something ships it reports the before/after window instead of a modeled guess.

--- a/content/use-cases/ai-search-lead.md
+++ b/content/use-cases/ai-search-lead.md
@@ -13,6 +13,8 @@ schedule: adhoc
 autonomy: acts-with-approval
 difficulty: intermediate
 setup_minutes: 20
+integrations:
+  - DevTune
 author:
   handle: theplgeek
   url: https://x.com/theplgeek


### PR DESCRIPTION
Adds a Marketing use case for **AI Search Lead** (`content/use-cases/ai-search-lead.md`).

Reads engine answers, citations, crawls, 404 demand, Search Console, and GA4 through a connected DevTune project, then drafts the next evidence-ranked page for review. Status is `proposed`. 

The listing tags `integrations: [DevTune]`. DevTune is not in the controlled vocabulary yet; maintainer issue: https://github.com/ZeroPointRepo/GrokBotDev/issues/11
