### PR TITLE
Add Sightkick plugin (marketing/seo)

### DIFF
--- a/content/plugins/sightkick.md
+++ b/content/plugins/sightkick.md
@@ -1,0 +1,41 @@
+---
+type: plugin
+name: "Sightkick"
+slug: sightkick
+tagline: "Run SEO end to end: AI-answer visibility, articles, publishing, Search Console proof."
+category: marketing
+subcategory: seo
+install_steps:
+  - "Create a Sightkick workspace at sightkick.so and add your website — the free analysis seeds your tracked prompts and keywords."
+  - "Connect Google Search Console in Settings, so the agent reads real impressions, clicks and positions instead of estimates."
+  - "Add the server to your MCP client — 'claude mcp add --transport http sightkick https://app.sightkick.so/mcp', or paste that URL into any client's custom-connector field. There is no API key: the first call opens an OAuth sign-in where you pick which workspace the grant binds to."
+  - "Paste the prompt below into your Grok Bot so 'how are we showing up in AI answers, and what should we publish next?' becomes a standing question."
+prompt: "You are setting up a Sightkick integration for me inside Grok Bot. Sightkick is an SEO/AEO autopilot: it tracks how ChatGPT, Gemini, Google AI Overviews and AI Mode answer my buyers' questions, researches keywords, writes and scores articles, schedules them on a calendar, and proves outcomes with Google Search Console data. First, read Sightkick's documentation at https://sightkick.so/mcp and its machine-readable reference at https://sightkick.so/llm-info so you understand the tool catalog before you call anything. Then connect to the remote MCP server at https://app.sightkick.so/mcp over streamable HTTP. There is no API key — authentication is OAuth 2.1 with dynamic client registration, and one grant is bound to one workspace, so when the consent screen appears, pick the workspace for the site we are working on. Then make this a standing capability. Whenever I ask how we are doing, or on whatever cadence I set: pull my AI-visibility summary and the prompts I track (get_visibility_summary, list_tracked_prompts), read the actual AI answers and the sources they cite (get_ai_answer, list_cited_sources), find where I am absent (list_visibility_gaps), and cross-read the Search Console proof (get_search_metrics). Report what moved, which competitors are being named instead of me, and which cited sources I do not appear in yet. Rules, and they are not optional. Follow the documented tool catalog exactly: never invent a tool, an argument or a field, and never guess a number — if a tool did not return it, say so plainly. Reads you may run freely: workspace, AI-visibility, keyword, article, calendar, outreach and activity reads. ASK ME FIRST, every single time, before anything that writes, publishes or spends money — generate_article (this costs real money per article), publish_article (this puts a page on my live site), queue_article, reschedule_article, set_autopilot_mode, and track_prompt or retire_prompt (these change what my subscription meters). Show me exactly what you are about to do, and wait for me to say yes. Every write is attributed to you in my workspace activity feed, so keep them deliberate and few. Confirm the connection now by calling get_workspace and showing me the workspace name, then my current AI-visibility summary."
+works_with: []
+project_url: "https://sightkick.so/mcp"
+repo_url: "https://github.com/sightkick-so/mcp"
+founder:
+  name: "Fabio Bergmann"
+  x_handle: "fabiobergmann"
+author:
+  handle: "sightkick"
+  url: "https://sightkick.so"
+  platform: web
+pricing_note: "From $39/mo after a 7-day free trial. Agent access is in every paid plan, never a separate tier."
+setup_minutes: 5
+added_at: "2026-08-28T17:11:54Z"
+updated_at: "2026-08-28T17:11:54Z"
+status: proposed
+---
+
+## What it does
+
+Sightkick is an SEO/AEO autopilot that runs the whole loop rather than one slice of it: it tracks how ChatGPT, Gemini, Google AI Overviews and AI Mode actually answer your buyers' questions, researches the keywords worth winning, writes and scores articles against a five-pillar rubric, schedules them on a publishing calendar, pushes them to your connected CMS, and then proves the outcome with Google Search Console data — impressions, clicks and positions, not estimates.
+
+The MCP server hands all of that to an agent: 31 tools over streamable HTTP, authenticated with OAuth 2.1, no API key anywhere. One grant binds to one workspace, and every write the agent makes is attributed to it in the workspace's activity feed, so an agent operating your SEO leaves an audit trail a human can read.
+
+## Use it in Grok Bot
+
+Paste the prompt on this page into a Grok Bot. Because auth is OAuth rather than a key, there is nothing to copy from a dashboard — the first call opens a sign-in and a workspace picker, and the connection is done. The bot reads Sightkick's own documentation first, wires up the server, then answers "how are we showing up in AI answers?" from real data: which prompts you win, which competitors get named instead of you, which sources the engines cite, and where Search Console says you actually moved.
+
+The prompt deliberately splits reads from writes. Reads run freely; anything that generates an article, publishes to your live site, changes your tracked-prompt panel or flips autopilot has to come back and ask you first, because each of those spends money or changes something public.


### PR DESCRIPTION
## What this adds

**Sightkick** — a plugin (`content/plugins/sightkick.md`). An SEO/AEO autopilot with a remote MCP server: AI-answer visibility tracking, keyword research, article writing/scoring, calendar scheduling, CMS publishing, and Google Search Console proof.

## Checklist
- [x] This PR adds exactly ONE new file under `content/`.
- [x] It follows CONTRIBUTING.md — required fields + the golden rules (G1–G8).
- [x] `npm run validate` passes locally (`171 entries - 36 plugins…  validate: OK`).
- [x] `slug` is kebab-case and exactly matches the filename.
- [ ] **I ran / used this myself end to end — see the honest note below.**
- [x] Every URL in the frontmatter resolves to real, relevant content.
- [x] The prompt body is the real, complete prompt — not a summary or a teaser.
- [x] The entry body is plain markdown — no raw HTML.
- [x] I did NOT set `verified_at`, `status: live`, `awesome_score`, `featured` or `sponsor`.
- [x] This is not an ad.
- [x] I license this contribution under CC BY 4.0.

## On G2, honestly

I'm the founder submitting my own tool, so let me be precise about what "works today" covers rather than tick the box flat.

**Verified end to end:** the MCP server itself. It's live at `https://app.sightkick.so/mcp` (streamable HTTP, OAuth 2.1 with dynamic client registration), published and `active` in the official MCP Registry as `so.sightkick/mcp`, and exercised in Claude Code, Claude desktop and ChatGPT. An unauthenticated request returns 401 — that's the OAuth challenge, not a fault. Discovery card: `https://app.sightkick.so/.well-known/mcp/server-card.json`. The tool names in the prompt are copied from that card, not from memory.

**Not verified:** I have not run it inside Grok Bot specifically — I don't have a SuperGrok Heavy / Cursor Ultra seat. Since Grok Bot follows Cursor's existing plugin and MCP policy rather than having its own controls, a standard remote MCP server should connect via `AddMcpServer` / `AuthenticateMcpServer`, but I haven't personally watched it happen and won't claim I have. Happy to have that treated as the open question in review, to adjust the install steps if the real Grok Bot flow differs, or to withdraw the PR if an unverified-in-Bot entry isn't something you want to carry.

## On G6

The prompt is written to be genuinely operable, not a funnel: it splits free reads from anything that spends money or publishes, and requires the bot to come back and ask before `generate_article`, `publish_article`, `queue_article`, `reschedule_article`, `set_autopilot_mode`, `track_prompt` or `retire_prompt`. Pricing is stated plainly in `pricing_note` and agent access isn't upsold — it's included in every paid plan.

## Where it came from

Own product. Docs: https://sightkick.so/mcp · machine-readable reference: https://sightkick.so/llm-info · repo: https://github.com/sightkick-so/mcp