### PR TITLE
Add TheFounder shareable bot

### DIFF
--- a/content/templates/thefounder.md
+++ b/content/templates/thefounder.md
@@ -1,0 +1,32 @@
+---
+type: template
+name: TheFounder
+slug: thefounder
+tagline: "Holds logins and the shared machine. Loads only after you tap send."
+description: "The founder's chief of staff and keeper of the shared machine. Route work to specialists. Do their job only when no teammate owns it. Do not recap your role unless asked."
+sharer:
+  handle: DaniAcostaAI
+  name: Daniel
+  url: https://x.com/DaniAcostaAI
+  platform: x
+share_url: https://x.ai/bot/Bt48h63v32_q_shWVlEBb
+tags: [business, ops, developer, automation, productivity, scheduled, agent-team, on-demand]
+primary_category: business
+includes: [instructions, memories, workflow, schedule, skills]
+includes_note: "Does not originate posts or spend. Load is after the founder taps send."
+added_at: "2026-08-29T09:30:00Z"
+updated_at: "2026-08-29T09:30:00Z"
+status: proposed
+---
+
+## What it does
+
+TheFounder is the founder's hub on a shared Grok Bot machine. Specialists draft posts, ads, and site work. This bot holds the live logins, copy-passes anything that will be published, and loads a signed draft only after the founder taps send. It never originates a post or a spend change. It also owns git backup of /workspace, weekday cleanup of shared scratch, and a Monday org review. It reports only what it can open on disk and does not invent token bills.
+
+## What you get
+
+A cloneable chief of staff: one bot writes, a different bot loads, you tap send. The machine backup and cleanup cadence come with it. Account IDs stay out of the shared copy.
+
+## Before you install
+
+Open the share link and read the instructions it carries before you add it. @DaniAcostaAI shared this one publicly, and adding it copies the setup into your own account rather than giving you access to theirs. It will not post or spend until you say yes.


### PR DESCRIPTION
## What

Adds `content/templates/thefounder.md` for the public TheFounder Grok Bot.

- Share page: https://x.ai/bot/Bt48h63v32_q_shWVlEBb
- `og:title`: TheFounder by Daniel
- Sharer: @DaniAcostaAI
- `status: proposed` (reviewer sets live / verified_at)
- No `source` tweet yet (X API blocked from this machine). Schema allows that on proposed. If you have the post URL, drop it in and I will add `source`.

## Checks

- [x] One new markdown file under `content/templates/`
- [x] slug matches filename (`thefounder`)
- [x] share_url is `https://x.ai/bot/` + 21-char id
- [x] no secrets / account IDs
- [x] did not set `verified_at`, `status: live`, or `featured`