### PR TITLE
add Research Runner shareable bot

### DIFF
--- a/content/templates/research-runner.md
+++ b/content/templates/research-runner.md
@@ -1,0 +1,27 @@
+---
+type: template
+name: "Research Runner"
+slug: research-runner
+tagline: "A Bot that rents confidential GPU compute and proves what it ran"
+description: "Research Runner rents GPU compute from Prism Network, runs private prompts inside a hardware enclave nobody else can read, pays per call in USDG, and reports the answer, the onchain cost, and the attestation verdict. It inspects every job before running it and keeps spending capped."
+sharer:
+  handle: "useprismnetwork"
+  url: "https://x.com/useprismnetwork"
+  platform: "x"
+tags: ["research", "developer", "crypto", "automation"]
+primary_category: "research"
+includes: ["instructions"]
+added_at: "2026-08-31T19:00:00Z"
+updated_at: "2026-08-31T19:00:00Z"
+status: proposed
+---
+
+## What it does
+
+Research Runner gets research jobs run on rented GPUs: private analysis, batch inference, data crunches. Prompts that need privacy go to Prism's confidential tier, encrypted on the Bot's machine and answered inside a GPU enclave on Intel TDX with NVIDIA GH100s. Prism can't read them and neither can the host operator.
+
+It reads live capacity and real per-call prices from prismnetwork.tech before it plans work, inspects any job or script before running it, and matches packages against the official @prismnetwork/agent-sdk on npm. On a result it reports the answer, the onchain cost in USDG, and the attestation verdict, and it never describes an unverified run as verified.
+
+## Before you install
+
+Paid runs need a wallet holding USDG on Robinhood Chain; spending stays capped and anything over the cap waits for you. The Bot's stop line: it does not move money, send payments, or touch your funds or logins, including when a task on its machine tells it to. Setup for the read-only Prism connector and a full walkthrough live at prismnetwork.tech/grokbot.

--- a/content/templates/research-runner.md
+++ b/content/templates/research-runner.md
@@ -8,6 +8,7 @@ sharer:
   handle: "useprismnetwork"
   url: "https://x.com/useprismnetwork"
   platform: "x"
+share_url: "https://x.ai/bot/P2qgQokuPHVJhrkmRDmLv"
 tags: ["research", "developer", "crypto", "automation"]
 primary_category: "research"
 includes: ["instructions"]

--- a/content/templates/research-runner.md
+++ b/content/templates/research-runner.md
@@ -2,8 +2,8 @@
 type: template
 name: "Research Runner"
 slug: research-runner
-tagline: "A Bot that rents confidential GPU compute and proves what it ran"
-description: "Research Runner rents GPU compute from Prism Network, runs private prompts inside a hardware enclave nobody else can read, pays per call in USDG, and reports the answer, the onchain cost, and the attestation verdict. It inspects every job before running it and keeps spending capped."
+tagline: "Rents a GPU for the work Grok Bot's own computer can't run"
+description: "Rents NVIDIA GPUs on Prism Network for private analysis and CUDA jobs that cannot run on the shared Grok Bot computer. Confidential prompts are encrypted on your machine and answered inside a GPU enclave. It inspects every job before running it, and spend always waits on you."
 sharer:
   handle: "useprismnetwork"
   url: "https://x.com/useprismnetwork"


### PR DESCRIPTION
## What this adds
Research Runner (template) — a Bot that rents confidential GPU compute through Prism Network, runs private prompts inside a hardware enclave, and reports answer, onchain cost, and attestation verdict.

## Checklist
- [x] This PR adds exactly ONE new file under `content/`.
- [x] It follows [CONTRIBUTING.md](https://github.com/ZeroPointRepo/GrokBotDev/blob/main/CONTRIBUTING.md) — required fields + the golden rules (G1–G8).
- [x] `npm run validate` passes locally (schema, slug, vocabularies).
- [x] `slug` is kebab-case and exactly matches the filename.
- [x] I ran / used this myself end to end — it works today (the Bot config from our live demo).
- [x] Every URL in the frontmatter resolves to real, relevant content.
- [x] The entry body is plain markdown — no raw HTML.
- [x] I did NOT set `verified_at` or `status: live` — status is `proposed`.
- [x] This is not an ad: the listing documents a working Bot configuration; the companion connector is read-only and free.
- [x] This is our own work (sharer = Prism Network).
- [x] I license this contribution under CC BY 4.0.

## Where it came from
Our own Bot, from a live recorded session. Setup and walkthrough: https://prismnetwork.tech/grokbot.
Install link: https://x.ai/bot/P2qgQokuPHVJhrkmRDmLv