### PR TITLE
Add The Accountant spend-watchdog template

### DIFF
--- a/content/templates/the-accountant.md
+++ b/content/templates/the-accountant.md
@@ -8,13 +8,17 @@ sharer:
   handle: brstorrie
   url: https://x.com/brstorrie
   platform: x
+source:
+  url: https://x.com/brstorrie/status/2094654945488252959
+  excerpt: "The Accountant watches your Grok Bot fleet for runaway tokens: over-polling, retry loops, empty stubs."
+  posted_at: "2026-09-01T05:13:50Z"
 share_url: https://x.ai/bot/Y_R1Ya9SIzQZguGTV5NCX
 tags: [developer, ops, saving-money, monitoring, automation, meta-bot, scheduled]
 primary_category: ops
 includes: [instructions, memories, workflow, schedule, skills]
 includes_note: "Weekday 7:30 local spend audit. First-run kickoff is for accounts already burning usage."
 added_at: "2026-09-01T05:00:00Z"
-updated_at: "2026-09-01T05:00:00Z"
+updated_at: "2026-09-01T05:13:50Z"
 status: proposed
 ---
 

--- a/content/templates/the-accountant.md
+++ b/content/templates/the-accountant.md
@@ -1,0 +1,31 @@
+---
+type: template
+name: The Accountant
+slug: the-accountant
+tagline: "Finds runaway-token Grok Bots and tells you what to tighten or kill"
+description: "A spend watchdog for a Grok Bot fleet. It ranks over-polling routines, bloated usage, retry loops, and empty roles, then recommends cheaper tools before more bots. It never invents billing numbers, never deletes, and never pauses anyone without a yes."
+sharer:
+  handle: brstorrie
+  url: https://x.com/brstorrie
+  platform: x
+share_url: https://x.ai/bot/Y_R1Ya9SIzQZguGTV5NCX
+tags: [developer, ops, saving-money, monitoring, automation, meta-bot, scheduled]
+primary_category: ops
+includes: [instructions, memories, workflow, schedule, skills]
+includes_note: "Weekday 7:30 local spend audit. First-run kickoff is for accounts already burning usage."
+added_at: "2026-09-01T05:00:00Z"
+updated_at: "2026-09-01T05:00:00Z"
+status: proposed
+---
+
+## What it does
+
+The Accountant watches a Grok Bot fleet for runaway tokens: over-polling cron, usage out of line with the job, retry loops, and empty or duplicate roles. It ranks by evidence — official usage if it exists, otherwise named proxies such as routine cadence and transcript size — and never invents token counts or dollar costs. Each offender gets one verdict: tighten, offload, skill up, repurpose, kill, or keep. It recommends Superpowers for retry loops, Grok Build CLI for heavy coding, connectors instead of browser polling, event-driven routines instead of cron, and Overwatch for VM backups only. It does not delete bots, recommend killing group chats or channels (`group.json` rooms), pause routines, run backups, or clean the shared machine. A weekday 7:30 local audit always reports; a clean bill is still one line.
+
+## What you get
+
+A ranked spend table, two or three actions, and a plugin/tool list. Users already burning usage paste the first-run kickoff so it audits immediately, then saves the weekday routine.
+
+## Before you install
+
+You need a Grok Bot account with at least one other bot or routine. Read the instructions on the share before you add it. It copies into your account; it does not get access to the author's. It will not pause or delete anything unasked, and it will not put group chats or channels on a kill list. Open the share link and read the instructions before you add it. Adding it copies the setup into your account; it does not get access to the author’s. Do not submit keys, internal URLs, or customer data.


### PR DESCRIPTION
## Summary
- One new file: `content/templates/the-accountant.md`
- Shareable bot template for The Accountant (spend watchdog)
- `status: proposed` (G8: no self-verify, no `verified_at` / live / awesome_score / featured)
- Sharer: `brstorrie` — `https://x.com/brstorrie`
- `share_url`: `https://x.ai/bot/Y_R1Ya9SIzQZguGTV5NCX` (21-char id)
- Body keeps the line that it does not recommend killing group chats/channels

## G1 source
- [x] Real X post: https://x.com/brstorrie/status/2094654945488252959
- excerpt is a partial quote; `posted_at` / `updated_at` `2026-09-01T05:13:50Z`

Draft. Do not merge. Status stays proposed.