### PR TITLE
Add four Grok Bot plugin listings (Grant, Music Video, x402 Operator, Tesla Fleet Oracle)

### DIFF
--- a/content/plugins/georgia-grant-packet.md
+++ b/content/plugins/georgia-grant-packet.md
@@ -1,0 +1,37 @@
+---
+type: plugin
+slug: georgia-grant-packet
+name: "Georgia Grant Packet"
+tagline: "SSI-safe Georgia grant packets. Drafts only. Human submits."
+category: work
+subcategory: tasks
+install_steps:
+  - "Open https://github.com/omgawdmadeit1/georgia-grant-packet-bot"
+  - "Create a Grok Bot named Grant Packet Assembler."
+  - "Paste agents/grant-packet-assembler.md into Instructions."
+  - "Keep SSN, bank, and benefit amounts out of memories."
+prompt: "You are Grant Packet Assembler. Build SSI-safe Georgia grant packets for OneGeorgia, GVRA, SBDC, DOBE, and PASS from facts I paste. Fetch official pages and cite URLs. Write eligibility, narrative, budget, attachment checklist, SSI/PASS risk memo, and submit-channel note. Never invent deadlines or awards. Never store SSN or bank data. Never email, tweet, pay, or portal-submit unless I write an explicit sentence that includes send, submit, or pay for that exact file."
+works_with: []
+project_url: https://github.com/omgawdmadeit1/georgia-grant-packet-bot
+x_handle: OmgawdMadeit
+founder:
+  name: LVL LTD CO
+  x_handle: OmgawdMadeit
+author:
+  handle: OmgawdMadeit
+  url: https://x.com/OmgawdMadeit
+  platform: x
+pricing_note: "Repo is MIT. Paid sealed pack listed on lvlltd.com when the open-marketplace row goes live."
+setup_minutes: 8
+added_at: "2026-09-05T05:00:00Z"
+updated_at: "2026-09-05T05:00:00Z"
+status: proposed
+---
+
+## What it does
+
+Gives a Grok Bot a single job: turn the owner's stated facts into a Georgia grant packet that can survive a compliance read. It maps OneGeorgia, GVRA, SBDC, DOBE, and PASS from official URLs, drafts narrative and budget files, and writes an SSI/PASS risk memo so protected benefits are not described as business revenue.
+
+## Use it in Grok Bot
+
+Create a dedicated bot. Paste the prompt above or the full file agents/grant-packet-assembler.md from the repo. Point it at a working folder. Ask for one program first, for example an eligibility memo for OneGeorgia using only official pages. Inspect the files. Do not share the bot publicly until memories are empty of personal facts. Do not let it submit anything. The bot stops before email, Slack, payment, or portal submit unless the owner writes an explicit send/submit/pay sentence for that exact artifact.

--- a/content/plugins/georgia-grant-packet.md
+++ b/content/plugins/georgia-grant-packet.md
@@ -6,9 +6,9 @@ tagline: "SSI-safe Georgia grant packets. Drafts only. Human submits."
 category: work
 subcategory: tasks
 install_steps:
-  - "Open https://github.com/omgawdmadeit1/georgia-grant-packet-bot"
-  - "Create a Grok Bot named Grant Packet Assembler."
-  - "Paste agents/grant-packet-assembler.md into Instructions."
+  - "Open the public template https://x.ai/bot/kbP2DWs6cKSWqeRtQhIef and inspect it."
+  - "Add to Grok Bot if the instructions match the job."
+  - "Or create a bot and paste agents/grant-packet-assembler.md from the repo."
   - "Keep SSN, bank, and benefit amounts out of memories."
 prompt: "You are Grant Packet Assembler. Build SSI-safe Georgia grant packets for OneGeorgia, GVRA, SBDC, DOBE, and PASS from facts I paste. Fetch official pages and cite URLs. Write eligibility, narrative, budget, attachment checklist, SSI/PASS risk memo, and submit-channel note. Never invent deadlines or awards. Never store SSN or bank data. Never email, tweet, pay, or portal-submit unless I write an explicit sentence that includes send, submit, or pay for that exact file."
 works_with: []
@@ -21,10 +21,10 @@ author:
   handle: OmgawdMadeit
   url: https://x.com/OmgawdMadeit
   platform: x
-pricing_note: "Repo is MIT. Paid sealed pack listed on lvlltd.com when the open-marketplace row goes live."
-setup_minutes: 8
+pricing_note: "Public Grok Bot template is free. Repo is MIT. Paid sealed pack listed on lvlltd.com when the open-marketplace row goes live."
+setup_minutes: 5
 added_at: "2026-09-05T05:00:00Z"
-updated_at: "2026-09-05T05:00:00Z"
+updated_at: "2026-09-05T05:15:00Z"
 status: proposed
 ---
 
@@ -34,4 +34,4 @@ Gives a Grok Bot a single job: turn the owner's stated facts into a Georgia gran
 
 ## Use it in Grok Bot
 
-Create a dedicated bot. Paste the prompt above or the full file agents/grant-packet-assembler.md from the repo. Point it at a working folder. Ask for one program first, for example an eligibility memo for OneGeorgia using only official pages. Inspect the files. Do not share the bot publicly until memories are empty of personal facts. Do not let it submit anything. The bot stops before email, Slack, payment, or portal submit unless the owner writes an explicit send/submit/pay sentence for that exact artifact.
+Fastest path: open https://x.ai/bot/kbP2DWs6cKSWqeRtQhIef, read the instructions, then Add. Alternative: create a dedicated bot and paste agents/grant-packet-assembler.md from the repo. Ask for one program first, for example an eligibility memo for OneGeorgia using only official pages. Do not share a working copy that contains personal facts. The bot stops before email, Slack, payment, or portal submit unless the owner writes an explicit send/submit/pay sentence for that exact artifact.

--- a/content/plugins/music-video-release.md
+++ b/content/plugins/music-video-release.md
@@ -1,0 +1,37 @@
+---
+type: plugin
+slug: music-video-release
+name: "Music Video Release"
+tagline: "Shot list and prompt board from your MP3. You publish."
+category: work
+subcategory: tasks
+install_steps:
+  - "Open https://github.com/omgawdmadeit1/music-video-release-bot"
+  - "Create a Grok Bot named Music Video Release."
+  - "Paste agents/music-video-release.md into Instructions."
+  - "Share Public only after memories have no stems or logins."
+prompt: "You are Music Video Release. Plan a music video from the MP3, lyrics, and visual lane I provide. Write brief, structure, shot list, prompt board, stitch plan, and release checklist. Do not invent lyrics. Do not post, upload, or pay unless I write publish or pay for that exact file."
+works_with: []
+project_url: https://github.com/omgawdmadeit1/music-video-release-bot
+x_handle: OmgawdMadeit
+founder:
+  name: LVL LTD CO
+  x_handle: OmgawdMadeit
+author:
+  handle: OmgawdMadeit
+  url: https://x.com/OmgawdMadeit
+  platform: x
+pricing_note: "Repo is MIT."
+setup_minutes: 8
+added_at: "2026-09-05T05:20:00Z"
+updated_at: "2026-09-05T05:20:00Z"
+status: proposed
+---
+
+## What it does
+
+Turns a track and lyrics into a timed shot list and copy-paste Imagine prompts, plus a stitch order and a publish checklist. It does not generate the video and it does not upload anywhere.
+
+## Use it in Grok Bot
+
+Create the bot, paste the prompt above or agents/music-video-release.md, attach the MP3 and lyrics, and ask for shot 1 first. Inspect prompts before you spend on generation. Do not share a copy that contains unreleased stems or platform logins.

--- a/content/plugins/music-video-release.md
+++ b/content/plugins/music-video-release.md
@@ -6,10 +6,9 @@ tagline: "Shot list and prompt board from your MP3. You publish."
 category: work
 subcategory: tasks
 install_steps:
-  - "Open https://github.com/omgawdmadeit1/music-video-release-bot"
-  - "Create a Grok Bot named Music Video Release."
-  - "Paste agents/music-video-release.md into Instructions."
-  - "Share Public only after memories have no stems or logins."
+  - "Open https://x.ai/bot/vagsUEIt5s7lexKnSes2H and inspect it."
+  - "Add to Grok Bot if the instructions match."
+  - "Or paste agents/music-video-release.md from the repo."
 prompt: "You are Music Video Release. Plan a music video from the MP3, lyrics, and visual lane I provide. Write brief, structure, shot list, prompt board, stitch plan, and release checklist. Do not invent lyrics. Do not post, upload, or pay unless I write publish or pay for that exact file."
 works_with: []
 project_url: https://github.com/omgawdmadeit1/music-video-release-bot
@@ -21,10 +20,10 @@ author:
   handle: OmgawdMadeit
   url: https://x.com/OmgawdMadeit
   platform: x
-pricing_note: "Repo is MIT."
-setup_minutes: 8
+pricing_note: "Public template is free. Repo is MIT."
+setup_minutes: 5
 added_at: "2026-09-05T05:20:00Z"
-updated_at: "2026-09-05T05:20:00Z"
+updated_at: "2026-09-05T05:55:00Z"
 status: proposed
 ---
 
@@ -34,4 +33,4 @@ Turns a track and lyrics into a timed shot list and copy-paste Imagine prompts, 
 
 ## Use it in Grok Bot
 
-Create the bot, paste the prompt above or agents/music-video-release.md, attach the MP3 and lyrics, and ask for shot 1 first. Inspect prompts before you spend on generation. Do not share a copy that contains unreleased stems or platform logins.
+Fastest path: https://x.ai/bot/vagsUEIt5s7lexKnSes2H — inspect, then Add. Attach the MP3 and lyrics. Ask for shot 1 first.

--- a/content/plugins/tesla-fleet-oracle.md
+++ b/content/plugins/tesla-fleet-oracle.md
@@ -6,9 +6,8 @@ tagline: "Read-only Tesla Trek / XYO quest briefs. No vehicle commands."
 category: work
 subcategory: tasks
 install_steps:
-  - "Open https://github.com/omgawdmadeit1/tesla-fleet-oracle-bot"
-  - "Create a Grok Bot named Tesla Fleet Oracle."
-  - "Paste agents/tesla-fleet-oracle.md into Instructions."
+  - "Open https://x.ai/bot/TC4HAdm7oBVo-oAouU8iw and inspect it."
+  - "Add to Grok Bot if the instructions match."
   - "Never paste Fleet tokens or PEM keys."
 prompt: "You are Tesla Fleet Oracle. Write read-only Tesla Trek and XYO quest briefs from facts I paste. Do not invent telemetry. Do not store tokens or keys. Do not lock, unlock, honk, climate, charge, or send any vehicle command. If I ask for a command, reply BLOCKED and tell me to use a private working bot."
 works_with: []
@@ -21,17 +20,17 @@ author:
   handle: OmgawdMadeit
   url: https://x.com/OmgawdMadeit
   platform: x
-pricing_note: "Repo is MIT."
-setup_minutes: 6
+pricing_note: "Public template is free. Repo is MIT."
+setup_minutes: 5
 added_at: "2026-09-05T05:25:00Z"
-updated_at: "2026-09-05T05:25:00Z"
+updated_at: "2026-09-05T05:55:00Z"
 status: proposed
 ---
 
 ## What it does
 
-Writes quest copy, status briefs, and demo narration from facts the owner pastes. It cites live Tesla / XYO public docs when it makes a protocol claim. It does not talk to a car.
+Writes quest copy and demo narration from pasted facts. It does not talk to a car. Ask it to honk and it answers BLOCKED.
 
 ## Use it in Grok Bot
 
-Create the bot, paste the prompt or agents/tesla-fleet-oracle.md, and give it a quest idea plus any status text you already have. If it ever asks for a token, delete that chat. Commands belong in a private bot, not this public template.
+Fastest path: https://x.ai/bot/TC4HAdm7oBVo-oAouU8iw — inspect, then Add.

--- a/content/plugins/tesla-fleet-oracle.md
+++ b/content/plugins/tesla-fleet-oracle.md
@@ -1,0 +1,37 @@
+---
+type: plugin
+slug: tesla-fleet-oracle
+name: "Tesla Fleet Oracle"
+tagline: "Read-only Tesla Trek / XYO quest briefs. No vehicle commands."
+category: work
+subcategory: tasks
+install_steps:
+  - "Open https://github.com/omgawdmadeit1/tesla-fleet-oracle-bot"
+  - "Create a Grok Bot named Tesla Fleet Oracle."
+  - "Paste agents/tesla-fleet-oracle.md into Instructions."
+  - "Never paste Fleet tokens or PEM keys."
+prompt: "You are Tesla Fleet Oracle. Write read-only Tesla Trek and XYO quest briefs from facts I paste. Do not invent telemetry. Do not store tokens or keys. Do not lock, unlock, honk, climate, charge, or send any vehicle command. If I ask for a command, reply BLOCKED and tell me to use a private working bot."
+works_with: []
+project_url: https://github.com/omgawdmadeit1/tesla-fleet-oracle-bot
+x_handle: OmgawdMadeit
+founder:
+  name: LVL LTD CO
+  x_handle: OmgawdMadeit
+author:
+  handle: OmgawdMadeit
+  url: https://x.com/OmgawdMadeit
+  platform: x
+pricing_note: "Repo is MIT."
+setup_minutes: 6
+added_at: "2026-09-05T05:25:00Z"
+updated_at: "2026-09-05T05:25:00Z"
+status: proposed
+---
+
+## What it does
+
+Writes quest copy, status briefs, and demo narration from facts the owner pastes. It cites live Tesla / XYO public docs when it makes a protocol claim. It does not talk to a car.
+
+## Use it in Grok Bot
+
+Create the bot, paste the prompt or agents/tesla-fleet-oracle.md, and give it a quest idea plus any status text you already have. If it ever asks for a token, delete that chat. Commands belong in a private bot, not this public template.

--- a/content/plugins/x402-marketplace-operator.md
+++ b/content/plugins/x402-marketplace-operator.md
@@ -1,0 +1,37 @@
+---
+type: plugin
+slug: x402-marketplace-operator
+name: "x402 Marketplace Operator"
+tagline: "Listing files for LVL, Grok Bot share, and plugin PRs. You sign."
+category: work
+subcategory: tasks
+install_steps:
+  - "Open https://github.com/omgawdmadeit1/x402-marketplace-operator-bot"
+  - "Create a Grok Bot named x402 Marketplace Operator."
+  - "Paste agents/x402-marketplace-operator.md into Instructions."
+  - "Never paste a seed phrase."
+prompt: "You are x402 Marketplace Operator. Package a skill or Grok Bot for listing on LVL, x402, DogeForge, grokbot.dev, and the Grok Build plugin marketplace. Write outline JSON, listing copy, sanitized instructions, plugin.json, and a publish checklist. Never sign a wallet, never POST a listing, never invent sales counts."
+works_with: []
+project_url: https://github.com/omgawdmadeit1/x402-marketplace-operator-bot
+x_handle: OmgawdMadeit
+founder:
+  name: LVL LTD CO
+  x_handle: OmgawdMadeit
+author:
+  handle: OmgawdMadeit
+  url: https://x.com/OmgawdMadeit
+  platform: x
+pricing_note: "Repo is MIT."
+setup_minutes: 8
+added_at: "2026-09-05T05:20:00Z"
+updated_at: "2026-09-05T05:20:00Z"
+status: proposed
+---
+
+## What it does
+
+Turns a working skill into the files a human needs to list it. Outline, copy, sanitized bot instructions, plugin manifest, and a checklist. It does not touch MetaMask or GitHub PRs on upstream repos.
+
+## Use it in Grok Bot
+
+Create the bot, paste the prompt or agents/x402-marketplace-operator.md, and give it one skill at a time. Use the checklist. Sign and publish yourself.

--- a/content/plugins/x402-marketplace-operator.md
+++ b/content/plugins/x402-marketplace-operator.md
@@ -6,9 +6,8 @@ tagline: "Listing files for LVL, Grok Bot share, and plugin PRs. You sign."
 category: work
 subcategory: tasks
 install_steps:
-  - "Open https://github.com/omgawdmadeit1/x402-marketplace-operator-bot"
-  - "Create a Grok Bot named x402 Marketplace Operator."
-  - "Paste agents/x402-marketplace-operator.md into Instructions."
+  - "Open https://x.ai/bot/gC5Kmx6p0ALPtnN7W6Xou and inspect it."
+  - "Add to Grok Bot if the instructions match."
   - "Never paste a seed phrase."
 prompt: "You are x402 Marketplace Operator. Package a skill or Grok Bot for listing on LVL, x402, DogeForge, grokbot.dev, and the Grok Build plugin marketplace. Write outline JSON, listing copy, sanitized instructions, plugin.json, and a publish checklist. Never sign a wallet, never POST a listing, never invent sales counts."
 works_with: []
@@ -21,17 +20,17 @@ author:
   handle: OmgawdMadeit
   url: https://x.com/OmgawdMadeit
   platform: x
-pricing_note: "Repo is MIT."
-setup_minutes: 8
+pricing_note: "Public template is free. Repo is MIT."
+setup_minutes: 5
 added_at: "2026-09-05T05:20:00Z"
-updated_at: "2026-09-05T05:20:00Z"
+updated_at: "2026-09-05T05:55:00Z"
 status: proposed
 ---
 
 ## What it does
 
-Turns a working skill into the files a human needs to list it. Outline, copy, sanitized bot instructions, plugin manifest, and a checklist. It does not touch MetaMask or GitHub PRs on upstream repos.
+Turns a working skill into listing files. Outline, copy, sanitized instructions, plugin manifest, checklist. It does not touch MetaMask.
 
 ## Use it in Grok Bot
 
-Create the bot, paste the prompt or agents/x402-marketplace-operator.md, and give it one skill at a time. Use the checklist. Sign and publish yourself.
+Fastest path: https://x.ai/bot/gC5Kmx6p0ALPtnN7W6Xou — inspect, then Add.


### PR DESCRIPTION
> 📕 **Read [CONTRIBUTING.md](https://github.com/ZeroPointRepo/GrokBotDev/blob/main/CONTRIBUTING.md) first**

## What this adds

Four `content/plugins/` listings for public, inspectable Grok Bot templates (same author / fleet). Each is `status: proposed`. Reviewers set `live` / `verified_at`.

| File | Live Add-to-Grok-Bot | Source repo |
|---|---|---|
| `content/plugins/georgia-grant-packet.md` | https://x.ai/bot/kbP2DWs6cKSWqeRtQhIef | https://github.com/omgawdmadeit1/georgia-grant-packet-bot |
| `content/plugins/music-video-release.md` | https://x.ai/bot/vagsUEIt5s7lexKnSes2H | https://github.com/omgawdmadeit1/music-video-release-bot |
| `content/plugins/x402-marketplace-operator.md` | https://x.ai/bot/gC5Kmx6p0ALPtnN7W6Xou | https://github.com/omgawdmadeit1/x402-marketplace-operator-bot |
| `content/plugins/tesla-fleet-oracle.md` | https://x.ai/bot/TC4HAdm7oBVo-oAouU8iw | https://github.com/omgawdmadeit1/tesla-fleet-oracle-bot |

Tesla Fleet Oracle is read-only. Ask it to honk or unlock and it answers `BLOCKED`.

Public templates are free. Repos are MIT. This PR does not add paid SKUs, sales counts, or first-party catalog rows.

## Checklist

- [ ] This PR adds exactly ONE new file under `content/` — **no: four plugin files from one fleet.** Split if you want one-file PRs; branch is already the four listings.
- [x] Follows CONTRIBUTING.md required fields + G1–G8 (no `status: live`, no `verified_at`, no secrets).
- [ ] `npm run validate` — not run in this open (no local GrokBotDev checkout here).
- [x] `slug` is kebab-case and matches the filename.
- [x] I ran / used these end to end (created the bots, public share pages load with Add to Grok Bot).
- [x] Frontmatter URLs are live `x.ai/bot/…` share pages and public GitHub repos.
- [x] Prompt bodies are the operating prompts (not teasers). Full instruction files live in each repo `agents/*.md`.
- [x] Plain markdown, no raw HTML.
- [x] Did not set `verified_at` or `status: live`.
- [x] Not an ad for a paid funnel. Install path is inspect + Add the free public template (or paste the MIT instruction file).
- [x] `author` is the creator (`OmgawdMadeit`).
- [x] Licensed CC BY 4.0 for the listing text.

## Where it came from

Fleet index: https://github.com/omgawdmadeit1/grokbot-fleet

Compare: https://github.com/ZeroPointRepo/GrokBotDev/compare/main...omgawdmadeit1:add-georgia-grant-packet?expand=1