### PR TITLE
Add Personal Assistant shareable bot template (proposed)

### DIFF
--- a/content/templates/personal-assistant.md
+++ b/content/templates/personal-assistant.md
@@ -1,0 +1,36 @@
+---
+type: "template"
+name: "Personal Assistant"
+slug: "personal-assistant"
+tagline: "Life admin for calendar, bills, trips, paperwork, and research"
+description: "Turns the messy thing on your desk — calendar collisions, bills, trips, paperwork, research — into a clear next step and usable drafts. Acts only after you approve."
+sharer:
+  handle: "gabe_onchain"
+  name: "Gabriel"
+  url: "https://x.com/gabe_onchain"
+  platform: "x"
+source:
+  url: "https://x.com/gabe_onchain/status/2096600080665006584"
+  excerpt: "I built a PA: your life admin for the boring desk stuff: calendar, bills, trips, paperwork, research, etc."
+  posted_at: "2026-09-06T14:03:06.000Z"
+share_url: "https://x.ai/bot/OWj_0o4Ik2FffupfloOwe"
+tags: ["personal", "productivity", "life-hacks", "calendar", "travel", "finance", "on-demand"]
+primary_category: "personal"
+includes: ["instructions", "memories", "workflow", "skills"]
+includes_note: "Ask-before spend, send, delete, or publish. Optional calendar and mail connectors when you connect them."
+added_at: "2026-09-06T14:03:06.000Z"
+updated_at: "2026-09-06T14:03:06.000Z"
+status: "proposed"
+---
+
+## What it does
+
+Personal Assistant is a single-user life and desk bot. You drop a messy real ask in front of it — a calendar collision, a bill, a trip, paperwork, or a research question — and it returns a clear next step plus usable drafts or packets. It is built to wait for your approval before spending money, sending externally, deleting, or publishing. It is not a company chief of staff and not a multi-bot org designer.
+
+## What you get
+
+A ready set of life-admin skills for calendar and meetings, communication drafts, money planning, trips, career packets, contracts, tax and debt organize, home inventory, research briefs, notes, reminders, and multi-day pursuits you can cancel or correct. Connect Google Calendar or Gmail yourself if you want mail and calendar context.
+
+## Before you install
+
+Open the share link and read the instructions before you add it. Adding it copies the setup into your own Grok Bot account. It will not move money, send mail, delete files, or publish unless you explicitly say yes to that exact action.


### PR DESCRIPTION
## Summary
Adds one shareable bot template under CONTRIBUTING §5b: `content/templates/personal-assistant.md`.

## Status
- `status: proposed` only
- `share_url` is the live x.ai/bot link: https://x.ai/bot/OWj_0o4Ik2FffupfloOwe
- Source: Gabe X post https://x.com/gabe_onchain/status/2096600080665006584
- Does **not** set `live`, `verified_at`, or `featured`

## Scope
- One new file only
- No other templates or site changes